### PR TITLE
Create CRE_RealFuels.cfg

### DIFF
--- a/GameData/CRE/compatibility/realfuels/CRE_RealFuels.cfg
+++ b/GameData/CRE/compatibility/realfuels/CRE_RealFuels.cfg
@@ -1,0 +1,213 @@
+//CRE MOD
+//Suggestion by Tostig v0.2 2021-08-28
+//Here begins the RealFuels adjustments
+//ENGINES
+//Black Anvil - RZ20 - LqdHydrogen & LqdOxygen
+@PART[black_anvil_engine_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[cre_liquid_hyrdrogen]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+        {
+           @name = LqdOxygen
+           @ratio = 0.1
+        }
+    }
+}
+
+//Black Arrow - Bristol Siddley Gamma - HTP & Kerosene
+@PART[black_arrow_engine_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 1
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = HTP
+			@ratio = 8
+		}
+    }
+}
+
+@PART[black_arrow_engine_s1_2]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 1
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = HTP
+			@ratio = 8
+		}
+    }
+}
+
+@PART[black_arrow_engine_s1_3]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 1
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = HTP
+			@ratio = 8
+		}
+    }
+}
+
+//Black Knight - Bristol Siddley Gamma 301 - HTP & Kerosene
+@PART[black_knight_engine_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 1
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = HTP
+			@ratio = 8
+		}
+    }
+}
+
+//Blue Steel - Armstrong Siddeley Stentor -  HTP & Kerosene
+@PART[blue_steel_engine_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        @PROPELLANT[LiquidFuel]
+		{
+			@name = Kerosene
+			@ratio = 1
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = HTP
+			@ratio = 8
+		}
+    }
+}
+
+//Blue Streak - Rolls-Royce RZ.2 - Kerosene	& LqdOxygen
+
+//FUEL TANKS
+//Black Anvil Fuel Tanks
+ 
+@PART[black_anvil_fuel_tank_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 450
+        maxAmount = 450
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_fuel_tank_s1_2]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 900
+        maxAmount = 900
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_fuel_tank_s1_3]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 1800
+        maxAmount = 1800
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_hemisphere_fuel_tank_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 225
+        maxAmount = 225
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+
+//FUEL TANKS
+//Black Anvil Fuel Tanks
+ 
+@PART[black_anvil_fuel_tank_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 450
+        maxAmount = 450
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_fuel_tank_s1_2]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 900
+        maxAmount = 900
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_fuel_tank_s1_3]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 1800
+        maxAmount = 1800
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}
+ 
+@PART[black_anvil_hemisphere_fuel_tank_s1_1]:NEEDS[RealFuels]:FOR[CRE]
+{
+    RESOURCE
+    {
+        name = LiquidFuel
+        amount = 225
+        maxAmount = 225
+    }
+ 
+    !RESOURCE[cre_liquid_hyrdrogen]{}
+}


### PR DESCRIPTION
If RealFuels is installed, changes relevant engines to use the relevant fuel types. Most important for HTP.